### PR TITLE
chore: upgrade to `v0.5.8`

### DIFF
--- a/mergestat.rb
+++ b/mergestat.rb
@@ -1,10 +1,10 @@
 class Mergestat < Formula
   desc "Query git repositories with SQL. Generate reports, perform status checks, analyze codebases. 🔍 📊"
   homepage "https://mergestat.com"
-  version "v0.5.7"
+  version "v0.5.8"
   url "https://github.com/mergestat/mergestat.git",
-    tag: "v0.5.7",
-    revision: "5b6c920656fd8bcad1d41b361756d6f3606aaa12"
+    tag: "v0.5.8",
+    revision: "ee2c34250adada3ceae771177788f7f7439c64e3"
   license "MIT"
 
   depends_on "go" => :build


### PR DESCRIPTION
https://github.com/mergestat/mergestat/releases/tag/v0.5.8