### PR TITLE
chore: bump `mergestat-lite` version

### DIFF
--- a/mergestat.rb
+++ b/mergestat.rb
@@ -1,10 +1,10 @@
 class Mergestat < Formula
   desc "Query git repositories with SQL. Generate reports, perform status checks, analyze codebases. 🔍 📊"
   homepage "https://mergestat.com"
-  version "v0.5.8"
+  version "v0.5.9"
   url "https://github.com/mergestat/mergestat-lite.git",
-    tag: "v0.5.8",
-    revision: "ee2c34250adada3ceae771177788f7f7439c64e3"
+    tag: "v0.5.9",
+    revision: "ec3af79e5a3b70d329407a00fcda6c7013a04a46"
   license "MIT"
 
   depends_on "go" => :build


### PR DESCRIPTION
to `v0.5.9`